### PR TITLE
Only replace first `version = ` line in Cargo.toml

### DIFF
--- a/src/cargo_proj.rs
+++ b/src/cargo_proj.rs
@@ -70,8 +70,8 @@ impl CargoProj {
     pub fn write_version(&mut self, version: &Version) -> RrResult<()> {
         if *version != self.version {
             modify_file(&self.cargo_toml, |contents| {
-                contents.replace(&format!("version = \"{}\"", self.version),
-                                 &format!("version = \"{}\"", version))
+                contents.replacen(&format!("version = \"{}\"", self.version),
+                                  &format!("version = \"{}\"", version), 1)
             })?;
 
             self.version = version.clone();


### PR DESCRIPTION
This ensures that only the package version is updated and not also dependency versions with the same version number. Fixes #6.